### PR TITLE
Stop irrelevant existence checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = (options) => {
                 const maybePromise = super.$beforeInsert(context);
 
                 return Promise.resolve(maybePromise).then(() => {
-                    if (opt.patch && this[options.passwordField] === undefined) return;
                     // hash the password
                     return this.generateHash();
                 });
@@ -35,6 +34,7 @@ module.exports = (options) => {
                 const maybePromise = super.$beforeUpdate(queryOptions, context);
 
                 return Promise.resolve(maybePromise).then(() => {
+                    if (queryOptions.patch && this[options.passwordField] === undefined) return;
                     // hash the password
                     return this.generateHash();
                 });

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = (options) => {
                 const maybePromise = super.$beforeInsert(context);
 
                 return Promise.resolve(maybePromise).then(() => {
+                    if (opt.patch && this[options.passwordField] === undefined) return;
                     // hash the password
                     return this.generateHash();
                 });


### PR DESCRIPTION
I encountered an issue where I was trying to `.patch` a single property and this library was complaining about how I didn't have a password set on the patch. This line ignores these situations.